### PR TITLE
validate: refactor linearization handling in operations.go

### DIFF
--- a/tests/robustness/validate/operations.go
+++ b/tests/robustness/validate/operations.go
@@ -32,10 +32,38 @@ var (
 	errFutureRevRespRequested = errors.New("request about a future rev with response")
 )
 
-func validateLinearizableOperationsAndVisualize(lg *zap.Logger, operations []porcupine.Operation, timeout time.Duration) (result porcupine.CheckResult, visualize func(basepath string) error) {
+type Results struct {
+	Info  porcupine.LinearizationInfo
+	Model porcupine.Model
+	Lg    *zap.Logger // Include logger in the Results struct
+}
+
+// Change the Visualize method to match the signature func(path string) error
+func (r Results) Visualize(path string) error {
+	// Directly use the logger from the Results struct
+	r.Lg.Info("Saving visualization", zap.String("path", path))
+	err := porcupine.VisualizePath(r.Model, r.Info, path)
+	if err != nil {
+		return fmt.Errorf("failed to visualize, err: %w", err)
+	}
+	return nil
+}
+
+func validateLinearizableOperationsAndVisualize(
+	lg *zap.Logger,
+	operations []porcupine.Operation,
+	timeout time.Duration,
+) (result porcupine.CheckResult, results Results) {
 	lg.Info("Validating linearizable operations", zap.Duration("timeout", timeout))
 	start := time.Now()
 	result, info := porcupine.CheckOperationsVerbose(model.NonDeterministicModel, operations, timeout)
+
+	results = Results{
+		Info:  info,
+		Model: model.NonDeterministicModel,
+		Lg:    lg,
+	}
+
 	switch result {
 	case porcupine.Illegal:
 		lg.Error("Linearization failed", zap.Duration("duration", time.Since(start)))
@@ -46,14 +74,7 @@ func validateLinearizableOperationsAndVisualize(lg *zap.Logger, operations []por
 	default:
 		panic(fmt.Sprintf("Unknown Linearization result %s", result))
 	}
-	return result, func(path string) error {
-		lg.Info("Saving visualization", zap.String("path", path))
-		err := porcupine.VisualizePath(model.NonDeterministicModel, info, path)
-		if err != nil {
-			return fmt.Errorf("failed to visualize, err: %w", err)
-		}
-		return nil
-	}
+	return result, results
 }
 
 func validateSerializableOperations(lg *zap.Logger, operations []porcupine.Operation, replay *model.EtcdReplay) (lastErr error) {

--- a/tests/robustness/validate/validate.go
+++ b/tests/robustness/validate/validate.go
@@ -35,11 +35,12 @@ func ValidateAndReturnVisualize(t *testing.T, lg *zap.Logger, cfg Config, report
 	linearizableOperations := patchLinearizableOperations(reports, persistedRequests)
 	serializableOperations := filterSerializableOperations(reports)
 
-	linearizable, visualize := validateLinearizableOperationsAndVisualize(lg, linearizableOperations, timeout)
+	linearizable, results := validateLinearizableOperationsAndVisualize(lg, linearizableOperations, timeout)
 	if linearizable != porcupine.Ok {
 		t.Error("Failed linearization, skipping further validation")
-		return visualize
+		return results.Visualize
 	}
+
 	// TODO: Use requests from linearization for replay.
 	replay := model.NewReplay(persistedRequests)
 
@@ -51,7 +52,7 @@ func ValidateAndReturnVisualize(t *testing.T, lg *zap.Logger, cfg Config, report
 	if err != nil {
 		t.Errorf("Failed validating serializable operations, err: %s", err)
 	}
-	return visualize
+	return results.Visualize
 }
 
 type Config struct {


### PR DESCRIPTION
Refactored validateLinearizableOperationsAndVisualize to remove the anonymous visualization function. Made a Results struct to store LinearizationInfo, Model, and the logger, simplifying the code.

Signed-off-by: VidhuSarwal <61115425+VidhuSarwal@users.noreply.github.com>


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
